### PR TITLE
Avoid 100% CPU on asyncio.sleep(0)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@ issues, offering improvements to the documentation or contributing code.
 We are certain the list is incomplete; please let one of us know by opening an [issue on GitHub](https://github.com/BruceSherwood/vpython-jupyter/issues) and we will be happy to add your name!
 
 + Wayne Decatur (@fomightez)
++ Tomokazu Higuchi (@higucheese)
 + Antti Kaihola (@akaihola)
 + Patrick Melanson (@pmelanson)
 + Gopal Sharma (@Hippogriff)

--- a/vpython/with_notebook.py
+++ b/vpython/with_notebook.py
@@ -162,7 +162,7 @@ async def wsperiodic():
                 msg = {'content': {'data': [m]}}
                 baseObj.glow.handle_msg(msg)
 
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
 
 loop = asyncio.get_event_loop()
 loop.create_task(wsperiodic())


### PR DESCRIPTION
When I used vpython on jupyter notebook, I faced a problem that a vpython kernel running on a remote server kept using 100% CPU. After surveying, I found the CPU spin was caused by asyncio.sleep(0) function. This issue ( https://github.com/python/asyncio/issues/398 ) describes the problem in detail.

To solve the problem, simply waiting longer than zero works well; the CPU usage changes from 100% to 1%. Of course, this change does not harm the performance of vpython in my sense.
