### PR TITLE
Fix the cron builds

### DIFF
--- a/vp_copy.yaml
+++ b/vp_copy.yaml
@@ -2,4 +2,5 @@
 # version is fine) that should be copied from conda-forge to the vpython
 # channel. This should include all dependencies of vpython that are
 # not in the defaults channel.
-{autobahn: null, six: null, txaio: null}
+- name: autobahn
+- name: txaio


### PR DESCRIPTION
The purpose of these builds is to automatically copy the couple of packages we need from conda-forge to the vpython conda channel.

This can be merged whenever it passes.