### PR TITLE
Fix namespace test

### DIFF
--- a/vpython/test/test_namespace.py
+++ b/vpython/test/test_namespace.py
@@ -118,6 +118,7 @@ API_NAMES = [
     'roundc',
     'scalecp',
     'scene',
+    'set_browser',
     'shape_object',
     'shapes',
     'shapespaths',


### PR DESCRIPTION
It turns out the test for the namespace of the package was failing on travis without raising an error. This fixes the problem (but not the travis test...)