### PR TITLE
Fix wheels on linux yet

### DIFF
--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -37,6 +37,31 @@ jobs:
         python setup.py bdist_wheel
         twine upload dist/*
 
+  linux_wheels:
+    runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v1
+        - name: Set up Python
+          uses: actions/setup-python@v1
+          with:
+            python-version: 3.8
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install twine
+      - name: Python wheels manylinux build
+        uses: RalfG/python-wheels-manylinux-build@v0.1
+        with:
+          python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
+          build-requirements: 'setuptools cython'
+      - name: Build and publish wheel
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_TOKEN }}
+        run: |
+          python setup.py bdist_wheel
+          twine upload wheelhouse/*-manylinux1_x86_64.whl
+
   sdist:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [macos-latest, windows-latest]  # No wheels on linux yet
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
Wheels on linux require a build configuration I've never understood. We weren't building wheels on linux before, so we won't here either (the linux wheel uploads were failing because of incorrect build configuration).