### PR TITLE
Only upload vpython wheels

### DIFF
--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -59,7 +59,7 @@ jobs:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_TOKEN }}
       run: |
-        twine upload wheelhouse/*-manylinux1_x86_64.whl
+        twine upload wheelhouse/vpython-*-manylinux1_x86_64.whl
 
   sdist:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Apparently this builds lots of wheels and then tries to upload all of them. we only want the vpython ones...