### PR TITLE
Add explicit error if the browser is set to qt on windows

### DIFF
--- a/vpython/no_notebook.py
+++ b/vpython/no_notebook.py
@@ -240,10 +240,15 @@ except:
     pass
 
 
-if platform.python_implementation() == 'PyPy' and _browsertype == 'pyqt':
-    raise RuntimeError('The pyqt browser cannot be used PyPy. Please use '
-                       'the default browser instead by removing '
-                       'set_browser("pyqt") from your code.')
+if _browsertype == 'pyqt':
+    if platform.python_implementation() == 'PyPy':
+        raise RuntimeError('The pyqt browser cannot be used PyPy. Please use '
+                           'the default browser instead by removing '
+                           'set_browser("pyqt") from your code.')
+    elif sys.platform.startswith('win'):
+        raise RuntimeError('The pyqt browser cannot be used on Windows. '
+                           'Please use the default browser instead by '
+                           'removing set_browser("pyqt") from your code.')
 
 
 def start_Qapp(port):


### PR DESCRIPTION
qt doesn't work on Windows for now because of issues with multiprocessing. This adds an explicit error if the user tries it.