### PR TITLE
A little more clock cleanup

### DIFF
--- a/Demos_no_notebook/HardSphereGas.py
+++ b/Demos_no_notebook/HardSphereGas.py
@@ -1,5 +1,4 @@
 from vpython import *
-from time import clock
 
 # Hard-sphere gas.
 
@@ -48,7 +47,7 @@ Atoms = []
 p = []
 apos = []
 pavg = sqrt(2*mass*1.5*k*T) # average kinetic energy p**2/(2mass) = (3/2)kT
-    
+
 for i in range(Natoms):
     x = L*random()-L/2
     y = L*random()-L/2
@@ -152,24 +151,24 @@ while True:
 
     # Update all positions
     for i in range(Natoms): Atoms[i].pos = apos[i] = apos[i] + (p[i]/mass)*dt
-    
+
     # Check for collisions
     hitlist = checkCollisions()
 
-    
+
     for i in range(Natoms):
         loc = apos[i]
         if abs(loc.x) > L/2:
             if loc.x < 0: p[i].x =  abs(p[i].x)
             else: p[i].x =  -abs(p[i].x)
-        
+
         if abs(loc.y) > L/2:
             if loc.y < 0: p[i].y = abs(p[i].y)
             else: p[i].y =  -abs(p[i].y)
-        
+
         if abs(loc.z) > L/2:
             if loc.z < 0: p[i].z =  abs(p[i].z)
             else: p[i].z =  -abs(p[i].z)
-    
+
 timer = clock()-timer
 print(timer)

--- a/vpython/rate_control.py
+++ b/vpython/rate_control.py
@@ -1,8 +1,8 @@
 import time
-try:
-    _clock = time.perf_counter # time.clock is deprecated in Python 3.3, gone in 3.8
-except:
-    _clock = time.clock
+
+_clock = time.perf_counter
+
+
 _tick = 1/60
 
 #import platform

--- a/vpython/vpython.py
+++ b/vpython/vpython.py
@@ -6,10 +6,10 @@ import platform
 from math import sqrt, tan, pi
 
 import time
-try:
-    clock = time.perf_counter # time.clock is deprecated in Python 3.3, gone in 3.8
-except:
-    clock = time.clock
+
+# vpython provides clock in its namespace
+clock = time.perf_counter
+
 import sys
 from . import __version__, __gs_version__
 from ._notebook_helpers import _isnotebook


### PR DESCRIPTION
This removes one more use of `time.clock` from a demo program and simplifies setting up vpython's `clock`. Since `perf_counter` was introduced in Python 3.3 and we support 3.5 and up we shouldn't need the `try`/`except`.