### PR TITLE
qt fails on python 3.8 and up, so raise a better error message

### DIFF
--- a/vpython/no_notebook.py
+++ b/vpython/no_notebook.py
@@ -249,6 +249,10 @@ if _browsertype == 'pyqt':
         raise RuntimeError('The pyqt browser cannot be used on Windows. '
                            'Please use the default browser instead by '
                            'removing set_browser("pyqt") from your code.')
+    elif sys.version_info.major == 3 and sys.version_info.minor >= 7:
+        raise RuntimeError('The pyqt browser cannot be used on Python 3.8. '
+                           'Please use the default browser instead by '
+                           'removing set_browser("pyqt") from your code.')
 
 
 def start_Qapp(port):


### PR DESCRIPTION
@atitus -- the qt browser fails on python 3.8 because of a change in multiprocessing I think (see #74). This workaround just raises an explicit error message in that case.