### PR TITLE
Allow vpython to be used remotely on a headless Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,12 @@ If you execute build_original_no_overload.py, and change the statement "if True:
 Note that in site-packages/vpython/vpython_libraries it is glowcomm.html that is used by launchers such as idle or spyder; glowcomm.js is used with Jupyter notebook (and a modified version is used in Jupyterlab).
 
 Placing console.log(....) statements in the GlowScript code or in the JavaScript section of glowcomm.html can be useful in debugging. You may also need to put debugging statements into site-packages/vpython/vpython.py.
+
+
+## Environment options
+
+The following options make sense for running VPython in a headless environment:
+ 
+* VPYTHON_PORT -> Specify the TCP/IP port number for the HTTP server.
+* VPYTHON_NOBROWSER -> Set this to disable trying to launch a browser.
+    The link will be printed instead.

--- a/vpython/no_notebook.py
+++ b/vpython/no_notebook.py
@@ -64,7 +64,7 @@ def find_free_port():
     return s.getsockname()[1]
 
 
-__HTTP_PORT = find_free_port()
+__HTTP_PORT = int(os.getenv("VPYTHON_PORT", find_free_port()))
 __SOCKET_PORT = find_free_port()
 
 try:
@@ -248,18 +248,25 @@ class WSserver(WebSocketServerProtocol):
 
 try:
     if platform.python_implementation() == 'PyPy':
-        server_address = ('', 0)      # let HTTPServer choose a free port
+        server_address = ('', int(os.getenv("VPYTHON_PORT", 0)))      # let HTTPServer choose a free port
         __server = HTTPServer(server_address, serveHTTP)
         port = __server.server_port   # get the chosen port
         # Change the global variable to store the actual port used
         __HTTP_PORT = port
-        _webbrowser.open('http://localhost:{}'.format(port)
-                         )  # or webbrowser.open_new_tab()
+        url = 'http://localhost:{}'.format(__HTTP_PORT)
+        if os.getenv("VPYTHON_NOBROWSER"):
+            print(url)
+        else:
+            _webbrowser.open(url)  # or webbrowser.open_new_tab()
     else:
         __server = HTTPServer(('', __HTTP_PORT), serveHTTP)
-        # or webbrowser.open_new_tab()
-        if _browsertype == 'default':  # uses default browser
-            _webbrowser.open('http://localhost:{}'.format(__HTTP_PORT))
+
+        url = 'http://localhost:{}'.format(__HTTP_PORT)
+        if os.getenv("VPYTHON_NOBROWSER"):
+            print(url)
+        else:
+            if _browsertype == 'default':  # uses default browser
+                _webbrowser.open(url)         # or webbrowser.open_new_tab()
 
 except:
     pass

--- a/vpython/vpython_libraries/glowcomm.html
+++ b/vpython/vpython_libraries/glowcomm.html
@@ -58,7 +58,15 @@ window.onload = function() {
     "use strict";
 	
 	//var sock = socket_port() // created by no_notebook.py
-	ws = new WebSocket("ws://localhost:"+sock)
+    let ws_url;
+    if (document.location.hostname.includes("localhost")){
+      ws_url = "ws://localhost:"+sock;
+    }
+    else {
+      ws_url = 'ws://' + document.location.hostname + ":" + sock;
+    }
+
+	ws = new WebSocket(ws_url);
 	ws.binaryType = "arraybuffer";
 
 	ws.onopen = function() {


### PR DESCRIPTION
These changes are designed for using VPython on a headless (no screen/keyboard attached, remotely operated) Raspberry Pi. This is ideal for graphing or visualizing vectors and sensor data.
It could be used in other headless contexts.

By specifying the environment variables `VPYTHON_PORT` a specific port number can be chosen instead of randomly assigning a free one. This means it can consistently offer the same port (useful when headless). 

Also on the headless Pi, it will be unable to launch a browser. So setting the `VPYTHON_NOBROWSER` environment variable just prints the URL instead.

It's imperfect, in that it still prints a "localhost" address instead of the device hostname (or .local name), and it seems not to play well with being closed, and then reopened on the same port (some kind of port binding issue). 

A further todo of mine would be to change the exit conditions - so it's not down to the last browser to leave, but instead a specific stop condition. This time perhaps based on a runtime setting.