### PR TITLE
Update to latest version of miniconda action in cron job

### DIFF
--- a/.github/workflows/copy_conda_packages.yml
+++ b/.github/workflows/copy_conda_packages.yml
@@ -10,7 +10,7 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - uses: goanpeca/setup-miniconda@v1
+    - uses: goanpeca/setup-miniconda@v2
       with:
         auto-update-conda: true
         python-version: 3.7


### PR DESCRIPTION
The most recent run of the workflow that copies packages from conda-forge to our channel. I'm hoping that upgrading to the latest version of the github action that installs miniconda does the trick.