### PR TITLE
Add rust to manylinux build

### DIFF
--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -45,6 +45,11 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
+    - name: Stable with rustfmt and clippy
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: default
+        toolchain: stable
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
`cryptography` needs rust to build, and but rust doesn't provide a wheel on Python 3.8.