### PR TITLE
Improve the `capture` implementation and fix its bugs

### DIFF
--- a/vpython/vpython.py
+++ b/vpython/vpython.py
@@ -3142,7 +3142,7 @@ class canvas(baseObj):
         if not isinstance(filename, str):
             raise TypeError("'filename' for Capture must be a string.")
 
-        if filename[-4:] != ".png":
+        if filename.endswith(".png"):
             filename += ".png"
 
         include_labels = "T" if capture_labels else "F"

--- a/vpython/vpython.py
+++ b/vpython/vpython.py
@@ -3138,17 +3138,18 @@ class canvas(baseObj):
     def pixel_to_world(self, value):
         raise AttributeError('pixel_to_world is read-only')
 
-    def capture(self, *s):
-        if len(s) == 0:
-            raise AttributeError('scene.capture requires at least one argument.')
-        filename = s[0]
-        if not isinstance(filename, str): raise AttributeError('A capture file name must be a string.')
-        if '.png' not in filename: filename += '.png'
+    def capture(self, filename, capture_labels=None):
+        if not isinstance(filename, str):
+            raise TypeError("'filename' for Capture must be a string.")
+
+        if filename[-4:] != ".png":
+            filename += ".png"
+
         include_labels = "T"
-        if len(s) == 2:
-            if s[1] == True: include_labels = "T"
-            else: include_labels = "F"
-        self.addmethod('capture', include_labels+filename)
+        if capture_labels is not None:
+            include_labels = "T" if capture_labels else "F"
+
+        self.addmethod("capture", include_labels + filename)
 
     @property
     def objects(self):

--- a/vpython/vpython.py
+++ b/vpython/vpython.py
@@ -3138,17 +3138,14 @@ class canvas(baseObj):
     def pixel_to_world(self, value):
         raise AttributeError('pixel_to_world is read-only')
 
-    def capture(self, filename, capture_labels=None):
+    def capture(self, filename, capture_labels=True):
         if not isinstance(filename, str):
             raise TypeError("'filename' for Capture must be a string.")
 
         if filename[-4:] != ".png":
             filename += ".png"
 
-        include_labels = "T"
-        if capture_labels is not None:
-            include_labels = "T" if capture_labels else "F"
-
+        include_labels = "T" if capture_labels else "F"
         self.addmethod("capture", include_labels + filename)
 
     @property


### PR DESCRIPTION
- Let Python do its work and use default and regular arguments instead of `*args`
- Use `TypeError` instead of `AttributeError`
- `".png" in "name.png.jpg"` will return `True`, instead we need to check the last four characters
- `include_labels` is now set to `"T"` explicitly via `capture_labels=True`
- Format code for better readability: add new lines after `:`, add whitespaces around `+`