### PR TITLE
Add python_abi to vpython channel

### DIFF
--- a/.github/workflows/copy_conda_packages.yml
+++ b/.github/workflows/copy_conda_packages.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install dependencies
       shell: bash -l {0}

--- a/vp_copy.yaml
+++ b/vp_copy.yaml
@@ -5,3 +5,4 @@
 - name: autobahn
 - name: txaio
 - name: vpython
+- name: python_abi


### PR DESCRIPTION
This should fix the conda install issue for people using the `vpython` conda channel