### PR TITLE
Update Python versions in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         platform: [macos-latest, windows-latest]  # No wheels on linux yet
     runs-on: ${{ matrix.platform }}
 

--- a/vpython/test/test_namespace.py
+++ b/vpython/test/test_namespace.py
@@ -163,6 +163,11 @@ def test_names_in_base_namspace():
         for name in ['dist', 'comb', 'prod', 'perm', 'isqrt']:
             api_name_set.add(name)
 
+    # Python 3.9 adds three more new math functions.
+    if python_version.major == 3 and python_version.minor >= 9:
+        for name in ['lcm', 'ulp', 'nextafter']:
+            api_name_set.add(name)
+
     print(sorted(api_name_set - current_names))
 
     # We may have added new names, so start with this weaker test


### PR DESCRIPTION
This does two things:

1. Add Python 3.9 to the list of versions that we test/upload to PyPI
2. Remove Python 3.6 from the list of versions we test/upload.