### PR TITLE
Fixed version check to encompass Python 3.10

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,7 @@ We are certain the list is incomplete; please let one of us know by opening an [
 + Kyle Dunn ([@kdunn926](https://github.com/kdunn926))
 + Brian Su ([@brianbbsu](https://github.com/brianbbsu))
 + [@0dminnimda](https://github.com/0dminnimda)
++ Mike Miller ([@Axe319](https://github.com/axe319))
 
 ## Full timeline of vpython development
 

--- a/vpython/__init__.py
+++ b/vpython/__init__.py
@@ -10,14 +10,14 @@ del glowscript_version
 # both of those.
 
 from ._notebook_helpers import _isnotebook, __is_spyder
-import platform
-__p = platform.python_version()
+import sys
+__v = sys.version_info
 
-# Delete platform now that we are done with it
-del platform
+# Delete sys now that we are done with it
+del sys
 
-__ispython3 = (__p[0] == '3')
-__require_notebook = (not __ispython3) or (__p[2] < '5') # Python 2.7 or 3.4 require Jupyter notebook
+__ispython3 = (__v.major == 3)
+__require_notebook = (not __ispython3) or (__v.minor < 5) # Python 2.7 or 3.4 require Jupyter notebook
 
 if __require_notebook and (not _isnotebook):
         s = "The non-notebook version of vpython requires Python 3.5 or later."


### PR DESCRIPTION
Fixed version check to also encompass 3.10. The prior check to see if notebook was required was equivalent to `'1' < '5'` when the Python version was 3.10 or greater.

edit: FIxes #173 