### PR TITLE
Updates for Python 3.10 and some housecleaning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, '3.10']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -11,8 +11,8 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-        platform: [macos-latest, windows-latest]  # No wheels on linux yet
+        python-version: [3.7, 3.8, 3.9, 3.10]
+        platform: [macos-latest, windows-latest]  # Wheels on linux below
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -55,9 +55,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install twine
     - name: Python wheels manylinux build
-      uses: RalfG/python-wheels-manylinux-build@v0.3.4
+      uses: RalfG/python-wheels-manylinux-build@v0.4.0
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38'
+        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
         build-requirements: 'setuptools cython'
     - name: Build and publish wheel
       env:
@@ -73,7 +73,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         platform: [macos-latest, windows-latest]  # Wheels on linux below
     runs-on: ${{ matrix.platform }}
 

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ import versioneer
 install_requires = ['jupyter', 'jupyter-server-proxy', 'numpy', 'ipykernel',
                     'autobahn>=18.8.2']
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 5:
-    install_requires.append('autobahn')
-
 setup_args = dict(
     name='vpython',
     packages=['vpython'],

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup_args = dict(
     ],
     ext_modules=extensions,
     install_requires=install_requires,
+    python_requires=">=3.7",
     package_data={'vpython': ['vpython_data/*',
                               'vpython_libraries/*',
                               'vpython_libraries/images/*']},

--- a/vpython/__init__.py
+++ b/vpython/__init__.py
@@ -9,21 +9,7 @@ del glowscript_version
 #  __gs_version__ exist before importing vpython, which itself imports
 # both of those.
 
-from ._notebook_helpers import _isnotebook, __is_spyder
-import sys
-__v = sys.version_info
-
-# Delete sys now that we are done with it
-del sys
-
-__ispython3 = (__v.major == 3)
-__require_notebook = (not __ispython3) or (__v.minor < 5) # Python 2.7 or 3.4 require Jupyter notebook
-
-if __require_notebook and (not _isnotebook):
-        s = "The non-notebook version of vpython requires Python 3.5 or later."
-        s += "\nvpython does work on Python 2.7 and 3.4 in the Jupyter notebook environment."
-        raise Exception(s)
-
+from ._notebook_helpers import __is_spyder
 
 from .vpython import canvas
 

--- a/vpython/vpython.py
+++ b/vpython/vpython.py
@@ -28,13 +28,8 @@ __all__ = ['Camera', 'GlowWidget', 'version', 'GSversion', 'Mouse', 'arrow', 'at
            'standardAttributes', 'text', 'textures', 'triangle', 'vertex',
            'wtext', 'winput', 'keysdown']
 
-__p = platform.python_version()
-_ispython3 = (__p[0] == '3')
 
-if _ispython3:
-    from inspect import signature # Python 3; needed to allow zero arguments in a bound function
-else:
-    from inspect import getargspec # Python 2; needed to allow zero arguments in a bound function
+from inspect import signature # Python 3; needed to allow zero arguments in a bound function
 
 # __version__ is the version number of the Jupyter VPython installer, generated in building the installer.
 version = [__version__, 'jupyter']


### PR DESCRIPTION
This PR does a few things:

- [x] Drops tests on Python 3.7 and adds tests on Python 3.10. *The minimum Python version is still `3.7`.*
- [x] Build wheels on Python 3.7 through 3.10
- [x] Drop a version check from `setup.py` that adds `autobahn` as a dependency for some old Python versions. We now require `autobahn` always.
- [x] Remove logic from `__init__.py` that is trying to check for Python 2.7 or 3.4, neither of which we support.