### PR TITLE
Use https instead of git for clone

### DIFF
--- a/.github/workflows/copy_conda_packages.yml
+++ b/.github/workflows/copy_conda_packages.yml
@@ -25,6 +25,6 @@ jobs:
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
       shell: bash -l {0}
       run: |
-        git clone git://github.com/glue-viz/conda-sync.git
+        git clone https://github.com/glue-viz/conda-sync.git
         mv conda-sync/sync.py .
         python drive_copy.py


### PR DESCRIPTION
This can be merged as soon as it passes. Copying packages to our own conda channel was broken for a while because they now require cloning using `https` and we were doing that.