### PR TITLE
Add Cython to build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = ["setuptools",
             "wheel",
-            "setuptools_scm"]
+            "setuptools_scm",
+            "cython"]
 build-backend = 'setuptools.build_meta'
 
 [tool.setuptools_scm]


### PR DESCRIPTION
It was omitted before, so the pure-python version of `vector` was used instead of the compiled version.