### PR TITLE
rebase patch for VPYTHON_HTTP_PORT and VPYTHON_NO_LAUNCH_BROWSER

### DIFF
--- a/vpython/no_notebook.py
+++ b/vpython/no_notebook.py
@@ -65,8 +65,10 @@ def find_free_port():
     s.bind(('', 0))  # find an available port
     return s.getsockname()[1]
 
-
-__HTTP_PORT = find_free_port()
+if "VPYTHON_HTTP_PORT" in os.environ:
+    __HTTP_PORT = int(os.environ["VPYTHON_HTTP_PORT"])
+else:
+    __HTTP_PORT = find_free_port()
 __SOCKET_PORT = find_free_port()
 
 try:
@@ -259,19 +261,24 @@ class WSserver(WebSocketServerProtocol):
 
 
 try:
+    no_launch = os.environ.get("VPYTHON_NO_LAUNCH_BROWSER", False)
+    if no_launch=="0":
+        no_launch=False
     if platform.python_implementation() == 'PyPy':
         server_address = ('', 0)      # let HTTPServer choose a free port
         __server = HTTPServer(server_address, serveHTTP)
         port = __server.server_port   # get the chosen port
         # Change the global variable to store the actual port used
         __HTTP_PORT = port
-        _webbrowser.open('http://localhost:{}'.format(port)
+        if not no_launch:
+            _webbrowser.open('http://localhost:{}'.format(port)
                          )  # or webbrowser.open_new_tab()
     else:
         __server = HTTPServer(('', __HTTP_PORT), serveHTTP)
         # or webbrowser.open_new_tab()
-        if _browsertype == 'default':  # uses default browser
-            _webbrowser.open('http://localhost:{}'.format(__HTTP_PORT))
+        if not no_launch:
+            if _browsertype == 'default':  # uses default browser
+                _webbrowser.open('http://localhost:{}'.format(__HTTP_PORT))
 
 except:
     pass


### PR DESCRIPTION
This partially addresses #217, by (optionally) not launching a browser and restricting the http port to a specified port.

This allows development with an open browser on a certain port, rather than having your default browser relaunched every time you run the code.

The relevant behavior is specified by two environment vars:

VPYTHON_HTTP_PORT

and

VPYTHON_NO_LAUNCH_BROWSER
