### PR TITLE
vector.__repr__ method now follows convention

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,6 +33,7 @@ We are certain the list is incomplete; please let one of us know by opening an [
 + [@0dminnimda](https://github.com/0dminnimda)
 + Mike Miller ([@Axe319](https://github.com/axe319))
 + Dan Miller ([@danx0r(https://github.com/danx0r))
++ Alex Herrera ([@aherrera1721](https://github.com/aherrera1721))
 
 ## Full timeline of vpython development
 

--- a/vpython/vector.py
+++ b/vpython/vector.py
@@ -51,7 +51,7 @@ class vector(object):
         return '<{:.6g}, {:.6g}, {:.6g}>'.format(self._x, self._y, self._z)
 
     def __repr__(self):
-        return '<{:.6g}, {:.6g}, {:.6g}>'.format(self._x, self._y, self._z)
+        return 'vector({:.6g}, {:.6g}, {:.6g})'.format(self._x, self._y, self._z)
 
     def __add__(self, other):
         if type(other) is vector:


### PR DESCRIPTION
This PR updates the `vector.__repr__` method to follow the [Python convention](https://docs.python.org/3/reference/datamodel.html#object.__repr__) which states, "If at all possible, [the returned value] should look like a valid Python expression that could be used to recreate an object with the same value (given an appropriate environment)."

Now, calling `eval(repr(v))` (where `v` is a `vector`) returns an equivalent `vector`.
