### PR TITLE
cyvector.__repr__ method now follows convention

### DIFF
--- a/vpython/cyvector.pyx
+++ b/vpython/cyvector.pyx
@@ -58,7 +58,7 @@ cdef class vector(object):
         return self
 
     def __repr__(self):
-        return '<{:.6g}, {:.6g}, {:.6g}>'.format(self._x, self._y, self._z)
+        return 'vector({:.6g}, {:.6g}, {:.6g})'.format(self._x, self._y, self._z)
 
     def __str__(self):
         return '<{:.6g}, {:.6g}, {:.6g}>'.format(self._x, self._y, self._z)


### PR DESCRIPTION
A follow up to #231, this PR udpates the `cyvector.__repr__` method to follow the Python convention.