### PR TITLE
Fix TypeError resulting from lack of __rmul__

### DIFF
--- a/vpython/cyvector.pyx
+++ b/vpython/cyvector.pyx
@@ -85,6 +85,12 @@ cdef class vector(object):
             return vector(self * other._x, self * other._y, self * other._z)
         return NotImplemented
 
+    def __rmul__(self, other): # required to prevent y * x error
+        if isinstance(other, (float, int)):
+            return vector(self._x * other, self._y * other, self._z * other)        
+        
+        return NotImplemented
+
     def __eq__(self,other):
         if type(self) is vector and type(other) is vector:
             return self.equals(other)


### PR DESCRIPTION
The current codebase has this comment regarding the lack of `__rmul__` in `cyvector.pyx`:

```py
    def __mul__(self, other):  ## in cython order of arguments is arbitrary, rmul doesn't exist
        if isinstance(other, (int, float)):
            return vector(self._x * other, self._y * other, self._z * other)
        elif isinstance(self, (int, float)):
            return vector(self * other._x, self * other._y, self * other._z)
        return NotImplemented
```

However, when cython is not installed the following will throw a `TypeError` due to a lack of ``__rmul``:
```py
1.0 * vector(3, 4, 8)
```

This contradicts the following statement in the README:
> If you don't have a compilier vpython should __still work__, but code that generates a lot of vectors may run a little slower.

The commit attached to this PR ensures the `__rmul__` seen in `vector.py` is also present in `cypython.pyx`.

Relevant discussion on forum:
https://groups.google.com/g/vpython-users/c/6ojA7FxcILA