### PR TITLE
Add auto-updates of GH actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+# Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request essentially adds a new GItHub action which checks whether our GitHub actions are up-to-date. This has become the standard way to keep with the rap[idly changing set of version numbers in our workflows.

Once merged, it will open pull requests to increment version numbees where needed.