### PR TITLE
Try bumping setup-miniconda to v3

### DIFF
--- a/.github/workflows/copy_conda_packages.yml
+++ b/.github/workflows/copy_conda_packages.yml
@@ -10,7 +10,7 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         python-version: 3.10


### PR DESCRIPTION
It seems this action has been bumped to v3 here:

https://github.com/conda-incubator/setup-miniconda

I'm hoping switching to this version will solve the trouble with python 3.1 being used in the older action.
