### PR TITLE
install_requires jupyterlab-vpython >= 3.1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
     extensions = [Extension('vpython.cyvector', ['vpython/cyvector.c'])]
 
 
-install_requires = ['jupyter', 'jupyter-server-proxy', 'jupyterlab-vpython', 'numpy', 'ipykernel',
+install_requires = ['jupyter', 'jupyter-server-proxy', 'jupyterlab-vpython>=3.1.7', 'numpy', 'ipykernel',
                     'autobahn>=22.6.1, <27']
 
 setup_args = dict(


### PR DESCRIPTION
Install the latest version of jupyterlab-vpython extension.