### PR TITLE
fix: replace pkg_resources with importlib.metadata for setuptools 82+

### DIFF
--- a/vpython/__init__.py
+++ b/vpython/__init__.py
@@ -1,17 +1,17 @@
-from importlib.metadata import version as get_distribution, PackageNotFoundError as DistributionNotFound
+from importlib.metadata import version, PackageNotFoundError
 
 from .gs_version import glowscript_version
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 __gs_version__ = glowscript_version()
 
 del glowscript_version
-del get_distribution
-del DistributionNotFound
+del version
+del PackageNotFoundError
 
 # Keep the remaining imports later to  ensure that __version__ and
 #  __gs_version__ exist before importing vpython, which itself imports

--- a/vpython/__init__.py
+++ b/vpython/__init__.py
@@ -1,4 +1,4 @@
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version as get_distribution, PackageNotFoundError as DistributionNotFound
 
 from .gs_version import glowscript_version
 


### PR DESCRIPTION
## Summary

pkg_resources was removed from setuptools 82.0.0 (PEP 740, Feb 2026). This breaks vpython when installed with the latest setuptools.

## Fix

Replace pkg_resources usage with the stdlib importlib.metadata module:
- get_distribution(name).version -> version(name)
- DistributionNotFound -> PackageNotFoundError

## Testing

pip install setuptools>=82
pip install vpython  # should work without pkg_resources error
python -c "import vpython; print(vpython.__version__)"

Fixes #285

Fixes #285